### PR TITLE
[CHORE]: Token Refresh Api Restdocs 수정

### DIFF
--- a/core/core-api/src/test/kotlin/com/myongjiway/core/api/controller/v1/auth/AuthControllerTest.kt
+++ b/core/core-api/src/test/kotlin/com/myongjiway/core/api/controller/v1/auth/AuthControllerTest.kt
@@ -14,7 +14,6 @@ import io.mockk.mockk
 import io.restassured.http.ContentType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.payload.JsonFieldType
@@ -71,7 +70,6 @@ class AuthControllerTest : RestDocsTest() {
         every { tokenService.refresh(any()) } returns TokenResult("ACCESS_TOKEN", "REFRESH_TOKEN")
 
         given()
-            .header(HttpHeaders.AUTHORIZATION, "Bearer access-token")
             .contentType(ContentType.JSON)
             .body(RefreshRequest("refreshToken"))
             .post("/auth/refresh")


### PR DESCRIPTION
## 📄 Summary
> - Token Refresh Api 요청 시 불필요한 헤더 부분을 제거했습니다.

## 🙋🏻 More
> closes #120